### PR TITLE
Fix publish libs action

### DIFF
--- a/.github/workflows/update_libs.yaml
+++ b/.github/workflows/update_libs.yaml
@@ -49,4 +49,3 @@ jobs:
           body: Update charm libs
           upsert: true
           ignore-no-changes: true
-          auto-merge: true


### PR DESCRIPTION
Enabling the auto-merge option in the create-pull-request action tried to squash the commits, which is not allowed by our repo config.