### PR TITLE
Fix scaled requirer charm

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ To deploy a single unit of OpenFGA using its default configuration.
 juju deploy openfga-k8s --channel edge
 juju deploy postgresql-k8s --channel edge
 juju integrate postgresql-k8s:database openfga-k8s
-juju run openfga-k8s/leader schema-upgrade --wait 30s
 ```
 
 #### New `openfga` interface:
@@ -37,7 +36,7 @@ requires:
 
 Then run
 ```shell
-charmcraft fetch-lib charms.openfga_k8s.v0.openfga
+charmcraft fetch-lib charms.openfga_k8s.v1.openfga
 ```
 
 Please read usage documentation about

--- a/lib/charms/openfga_k8s/v1/openfga.py
+++ b/lib/charms/openfga_k8s/v1/openfga.py
@@ -87,7 +87,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 PYDEPS = ["pydantic<2.0"]
 
 logger = logging.getLogger(__name__)
@@ -236,11 +236,17 @@ class OpenFGARequires(Object):
 
     def _on_relation_created(self, event: RelationCreatedEvent) -> None:
         """Handle the relation-created event."""
+        if not self.model.unit.is_leader():
+            return
+
         databag = event.relation.data[self.model.app]
         OpenfgaRequirerAppData(store_name=self.store_name).dump(databag)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the relation-changed event."""
+        if not self.model.unit.is_leader():
+            return
+
         if not (app := event.relation.app):
             return
         databag = event.relation.data[app]

--- a/lib/charms/openfga_k8s/v1/openfga.py
+++ b/lib/charms/openfga_k8s/v1/openfga.py
@@ -244,9 +244,6 @@ class OpenFGARequires(Object):
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the relation-changed event."""
-        if not self.model.unit.is_leader():
-            return
-
         if not (app := event.relation.app):
             return
         databag = event.relation.data[app]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -94,6 +94,18 @@ async def test_requirer_charm_integration(ops_test: OpsTest) -> None:
     openfga_requires_unit = ops_test.model.applications["openfga-requires"].units[0]
     assert "running with store" in openfga_requires_unit.workload_status_message
 
+    app = ops_test.model.applications["openfga-requires"]
+
+    await app.scale(2)
+
+    await ops_test.model.wait_for_idle(
+        apps=["openfga-requires"],
+        status="active",
+        raise_on_blocked=True,
+        timeout=1000,
+        wait_for_exact_units=2,
+    )
+
 
 async def test_has_http_ingress(ops_test: OpsTest) -> None:
     # Get the traefik address and try to reach openfga

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -46,6 +46,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm: str, test_charm: str) 
             test_charm,
             application_name="openfga-requires",
             series="jammy",
+            num_units=2,
         ),
     )
 
@@ -93,18 +94,6 @@ async def test_requirer_charm_integration(ops_test: OpsTest) -> None:
 
     openfga_requires_unit = ops_test.model.applications["openfga-requires"].units[0]
     assert "running with store" in openfga_requires_unit.workload_status_message
-
-    app = ops_test.model.applications["openfga-requires"]
-
-    await app.scale(2)
-
-    await ops_test.model.wait_for_idle(
-        apps=["openfga-requires"],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-        wait_for_exact_units=2,
-    )
 
 
 async def test_has_http_ingress(ops_test: OpsTest) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -84,7 +84,21 @@ def test_on_config_changed(
                     "OPENFGA_PLAYGROUND_ENABLED": "false",
                 },
             },
-        }
+        },
+        "checks": {
+            "openfga-http-check": {
+                "override": "replace",
+                "period": "1m",
+                "http": {"url": "http://localhost:8080/healthz"},
+            },
+            "openfga-grpc-check": {
+                "override": "replace",
+                "period": "1m",
+                "exec": {
+                    "command": "grpc_health_probe -addr localhost:8081",
+                },
+            },
+        },
     }
 
 


### PR DESCRIPTION
This PR addresses a bug where if a requirer charm that is related to the OpenFGA charm is scaled to more than 1 unit, the following error shows in the logs:

```
unit-temporal-k8s-1: 14:29:17 ERROR unit.temporal-k8s/1.juju-log openfga:18: Uncaught exception while in charm code:
...
File "/var/lib/juju/agents/unit-temporal-k8s-1/charm/lib/charms/openfga_k8s/v1/openfga.py", line 240, in _on_relation_created
    OpenfgaRequirerAppData(store_name=self.store_name).dump(databag)
  File "/var/lib/juju/agents/unit-temporal-k8s-1/charm/lib/charms/openfga_k8s/v1/openfga.py", line 146, in dump
    databag[field.alias or key] = (
  File "/var/lib/juju/agents/unit-temporal-k8s-1/charm/venv/ops/model.py", line 1474, in __setitem__
    self._validate_write(key, value)
  File "/var/lib/juju/agents/unit-temporal-k8s-1/charm/venv/ops/model.py", line 1460, in _validate_write
    raise RelationDataAccessError(
ops.model.RelationDataAccessError: temporal-k8s/1 is not leader and cannot write application data.
```

Therefore, it checks for unit leadership before dumping data in the relation databag.

It also updates the README to reflect the new library version and instructions, as running a schema upgrade action is no longer required when the charm is initially deployed.