### PR TITLE
refactor: setup log folder and adjust tests + pinned main dependecies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-ops >= 2.3.0
-requests >= 2.25.1
-jsonschema >= 3.2.0
+ops == 2.10.0
+requests == 2.31.0
+jsonschema==4.21.1
 cryptography >= 3.4.8
-lightkube
-lightkube-models
+lightkube===0.15.0
+lightkube-models==1.29.0.6
 pydantic<2.0

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Constants."""
+import os
 
 WORKLOAD_CONTAINER = "openfga"
 SERVICE_NAME = "openfga"
@@ -11,7 +12,8 @@ REQUIRED_SETTINGS = [
     "OPENFGA_AUTHN_PRESHARED_KEYS",
 ]
 
-LOG_FILE = "/openfga-k8s.log"
+LOG_FOLDER = "/var/log/openfga"
+LOG_FILE_PATH = os.path.join(LOG_FOLDER, "openfga-k8s.log")
 
 OPENFGA_SERVER_HTTP_PORT = 8080
 OPENFGA_METRICS_HTTP_PORT = 2112

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,7 @@ from ops.testing import Harness
 
 logger = logging.getLogger(__name__)
 
-LOG_FILE = "/openfga-k8s.log"
+LOG_FILE_PATH = "/var/log/openfga/openfga-k8s.log"
 DB_USERNAME = "test-username"
 DB_PASSWORD = "test-password"
 DB_ENDPOINT = "postgresql-k8s-primary.namespace.svc.cluster.local:5432"
@@ -74,7 +74,7 @@ def test_on_config_changed(
                 "override": "merge",
                 "startup": "disabled",
                 "summary": "OpenFGA",
-                "command": f"sh -c 'openfga run --log-format json --log-level debug 2>&1 | tee -a {LOG_FILE}'",
+                "command": f"sh -c 'openfga run --log-format json --log-level debug 2>&1 | tee -a {LOG_FILE_PATH}'",
                 "environment": {
                     "OPENFGA_AUTHN_METHOD": "preshared",
                     "OPENFGA_AUTHN_PRESHARED_KEYS": mocked_token_urlsafe.return_value,


### PR DESCRIPTION
# Description
This PR adds the creation of the folder `/var/log/openfga` to adhere to [filesystem hierarchy standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#varlogLogFilesAndDirectories)), which opens the door for future log rotation handling.

## Test
- unit tests
- integration tests
- manual testing to ensure COS integration works as expected


![loki-logs](https://github.com/canonical/openfga-operator/assets/6314859/0b24fb07-e8b2-45a7-af28-3fd7af61c843)



### Side note
This PR closes https://github.com/canonical/openfga-rock/issues/4 