### PR TITLE
ci: fix the broken charm lib release workflow

### DIFF
--- a/.github/workflows/release_libs.yaml
+++ b/.github/workflows/release_libs.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - "lib/charms/openfga_k8s/**"
+      - "lib/charms/openfga_k8s/v1/**"
 
 jobs:
   release-libs:


### PR DESCRIPTION
The charm library release workflow is broken due to how the `canonical/charming-actions/release-libraries` works. In the openfga case, it needs to pin down the subdirectory of the maintained charm lib.