### PR TITLE
fix: fix the dependency required by k8s resource patch lib

### DIFF
--- a/unit-requirements.txt
+++ b/unit-requirements.txt
@@ -3,6 +3,7 @@ charmhelpers
 coverage[toml]
 cryptography
 jsonschema
+lightkube
 pytest
 pytest-mock
 requests


### PR DESCRIPTION
This pull request aims to fix the unit test dependency `lightkube` required by k8s resource path library.