### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -38,14 +38,18 @@ peers:
 provides:
   openfga:
     interface: openfga
+    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   send-ca-cert:
     description: |
       Transfer CA certificates to client charmed operators.
     interface: certificate_transfer
+    optional: true
 
 requires:
   http-ingress:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -38,7 +38,6 @@ peers:
 provides:
   openfga:
     interface: openfga
-    optional: true
   grafana-dashboard:
     interface: grafana_dashboard
     optional: true


### PR DESCRIPTION
## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.
