### PR TITLE
fix: do not pass api token in the openfga integration databag

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -333,7 +333,6 @@ class OpenFGAOperatorCharm(CharmBase):
             store_id=store_id,
             http_api_url=self.http_ingress_integration.url,
             grpc_api_url=self.grpc_ingress_integration.url,
-            token=token,
             token_secret_id=token_secret_id,
             relation_id=event.relation.id,
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,7 +52,7 @@ async def charm(ops_test: OpsTest) -> str | Path:
 @pytest_asyncio.fixture(scope="module")
 async def tester_charm(ops_test: OpsTest) -> Path:
     if tester := next(Path("./tests/charms/openfga_requires").glob("*.charm"), None):
-        return tester
+        return tester.resolve()
 
     logger.info("Building OpenFGA tester charm locally")
     return await ops_test.build_charm("./tests/charms/openfga_requires/")


### PR DESCRIPTION
This pull request aims to not pass the api token explicitly in the openfga integration databag.

This tries to resolve the https://github.com/canonical/openfga-operator/issues/263.